### PR TITLE
Add docs & small fix to makefile

### DIFF
--- a/crate/bit-allocator/src/lib.rs
+++ b/crate/bit-allocator/src/lib.rs
@@ -6,6 +6,18 @@ extern crate bit_field;
 use bit_field::BitField;
 use core::ops::Range;
 
+/// Allocator of a bitmap, able to allocate / free bits.
+///
+/// CAP: the bitmap has a total of CAP bits, numbered from 0 to CAP-1 inclusively.
+///
+/// alloc: allocate a free bit.
+/// dealloc: free an allocated bit.
+///
+/// insert: mark bits in the range as allocated
+/// remove: reverse of insert
+///
+/// any: whether there are free bits remaining
+/// test: whether a specific bit is free
 pub trait BitAlloc: Default {
     const CAP: usize;
     fn alloc(&mut self) -> Option<usize>;
@@ -23,6 +35,7 @@ pub type BitAlloc1M = BitAllocCascade16<BitAlloc64K>;
 pub type BitAlloc16M = BitAllocCascade16<BitAlloc1M>;
 pub type BitAlloc256M = BitAllocCascade16<BitAlloc16M>;
 
+/// Implement the bit allocator by segment tree algorithm.
 #[derive(Default)]
 pub struct BitAllocCascade16<T: BitAlloc> {
     bitset: u16,
@@ -77,6 +90,8 @@ impl<T: BitAlloc> BitAllocCascade16<T> {
 #[derive(Default)]
 pub struct BitAlloc16(u16);
 
+/// BitAlloc16 acts as the leaf (except the leaf bits of course) nodes
+/// in the segment trees.
 impl BitAlloc for BitAlloc16 {
     const CAP: usize = 16;
 

--- a/crate/process/src/scheduler.rs
+++ b/crate/process/src/scheduler.rs
@@ -212,3 +212,4 @@ fn expand<T: Default + Clone>(vec: &mut Vec<T>, id: usize) {
     let len = vec.len();
     vec.resize(len.max(id + 1), T::default());
 }
+

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -143,6 +143,7 @@ $(kernel): kernel $(assembly_object_files) $(linker_script)
 		$(assembly_object_files) target/x86_64-blog_os/$(mode)/libucore.a
 
 kernel:
+	@mkdir build/$(arch) -p
 	@CC=$(cc) cargo xbuild $(build_args)
 
 # compile assembly files


### PR DESCRIPTION
* Add docs to bit allocator so its responsibilities is clarified.

* Original makefile is missing a `mkdir build`, causing build failure if the user is starting from a clean repository.